### PR TITLE
Revert "Update DesktopPopup.js"

### DIFF
--- a/src/components/responsive/DesktopPopup.js
+++ b/src/components/responsive/DesktopPopup.js
@@ -15,6 +15,11 @@ import styled from 'styled-components'
 
 const CustomPopup = styled(Popup)`
    &&& {
+      padding: 0px;
+      right: 12px !important;
+      top: 50px !important;
+      position: fixed !important;
+
       .account-dropdown {
          width: 290px;
          min-height: 100px;
@@ -123,7 +128,7 @@ const DesktopPopup = ({
             type='desktop'
          />
       }
-      position='bottom right'
+      position='right center'
       open={popupOpen}
       on='click'
       onClose={handleClose}


### PR DESCRIPTION
Reverts nearprotocol/near-wallet#260

Popup doesn't look right in Safari

<img width="385" alt="Screen Shot 2019-11-29 at 9 18 51 PM" src="https://user-images.githubusercontent.com/126710/69895942-e367c800-12ed-11ea-9d2b-f8a7faf8fd93.png">
