### PR TITLE
Remove regex pattern attribute from seed phrase recovery input field

### DIFF
--- a/src/components/accounts/RecoverAccountSeedPhraseForm.js
+++ b/src/components/accounts/RecoverAccountSeedPhraseForm.js
@@ -26,7 +26,6 @@ const RecoverAccountSeedPhraseForm = ({
                     placeholder='correct horse battery staple'
                     required
                     tabIndex='2'
-                    pattern='[a-zA-Z ]*'
                     style={{ width: '100%' }}
                 />
             </Fragment>


### PR DESCRIPTION
Fixes the immediate problem posed in #256, which is pretty critical. Open to suggestions on a new regex pattern.