### PR TITLE
Input font size: increase to 16px

### DIFF
--- a/src/components/GlobalStyle.js
+++ b/src/components/GlobalStyle.js
@@ -126,7 +126,7 @@ export default createGlobalStyle`
 
    input {
       font-family: "benton-sans",sans-serif !important;
-      font-size: 14px !important;
+      font-size: 16px !important;
       width: 100% !important;
       height: 48px !important;
       border: 2px solid #f8f8f8 !important;


### PR DESCRIPTION
Anything lower than 16px will cause the mobile browser to zoom in, resulting in bad UX.