### PR TITLE
Allow to add subdomain to accountId on Send Money page

### DIFF
--- a/src/components/accounts/AccountFormAccountId.js
+++ b/src/components/accounts/AccountFormAccountId.js
@@ -17,7 +17,7 @@ class AccountFormAccountId extends Component {
     }
 
     handleChangeAccountId = (e, { name, value }) => {
-        if (value.match(/[^a-zA-Z0-9_-]/)) {
+        if ((this.props.type !== 'send-money' && value.match(/[^a-zA-Z0-9_-]/)) || value.match(/[^a-zA-Z0-9._-]/)) {
             return false
         }
 

--- a/src/components/accounts/AccountFormAccountId.js
+++ b/src/components/accounts/AccountFormAccountId.js
@@ -17,7 +17,7 @@ class AccountFormAccountId extends Component {
     }
 
     handleChangeAccountId = (e, { name, value }) => {
-        if ((this.props.type !== 'send-money' && value.match(/[^a-zA-Z0-9_-]/)) || value.match(/[^a-zA-Z0-9._-]/)) {
+        if (value.match(this.props.pattern)) {
             return false
         }
 
@@ -78,7 +78,8 @@ AccountFormAccountId.propTypes = {
 }
 
 AccountFormAccountId.defaultProps = {
-    autoFocus: false
+    autoFocus: false,
+    pattern: /[^a-zA-Z0-9._-]/
 }
 
 const mapDispatchToProps = {

--- a/src/components/accounts/CreateAccountForm.js
+++ b/src/components/accounts/CreateAccountForm.js
@@ -21,6 +21,7 @@ const CreateAccountForm = ({
          formLoader={formLoader}
          handleChange={handleChange}
          type='create'
+         pattern={/[^a-zA-Z0-9_-]/}
       />
 
       {false ? (

--- a/src/components/send-money/SendMoneyFirstStep.js
+++ b/src/components/send-money/SendMoneyFirstStep.js
@@ -49,7 +49,6 @@ const SendMoneyFirstStep = ({
                                  handleChange={handleChange}
                                  defaultAccountId={accountId}
                                  autoFocus={true}
-                                 type='send-money'
                               />
                               <Responsive as={RequestStatusBox} minWidth={768} requestStatus={requestStatus} />
                            </List.Content>

--- a/src/components/send-money/SendMoneyFirstStep.js
+++ b/src/components/send-money/SendMoneyFirstStep.js
@@ -49,6 +49,7 @@ const SendMoneyFirstStep = ({
                                  handleChange={handleChange}
                                  defaultAccountId={accountId}
                                  autoFocus={true}
+                                 type='send-money'
                               />
                               <Responsive as={RequestStatusBox} minWidth={768} requestStatus={requestStatus} />
                            </List.Content>


### PR DESCRIPTION
@vgrichina do we need any additional change for it (#311)? For example, will `getAccount` wallet function work with a subdomain in accountId?