### PR TITLE
Fix account creation when the network is slow (#258)

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -54,7 +54,7 @@ export function handleRefreshAccount(history, loader = true) {
                 if (e.message && e.message.indexOf('does not exist while viewing') !== -1) {
                     // We have an account in the storage, but it doesn't exist on blockchain. We probably nuked storage so just redirect to create account
                     // TODO: Offer to remove specific account vs clearing everything?
-                    wallet.clearState()
+                    wallet.clearAccountState()
                     wallet.redirectToCreateAccount(
                         {
                             reset_accounts: true

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -4,9 +4,12 @@ import { Wallet } from '../utils/wallet'
 import { getTransactions as getTransactionsApi } from '../utils/explorer-api'
 import { push } from 'connected-react-router'
 
+import { WALLET_CREATE_NEW_ACCOUNT_URL } from '../utils/wallet'
+
 export const REFRESH_ACCOUNT = 'REFRESH_ACCOUNT'
 export const LOADER_ACCOUNT = 'LOADER_ACCOUNT'
 export const REFRESH_URL = 'REFRESH_URL'
+
 
 // TODO: Refactor whole mess with handleRefreshAccount / handleLoginUrl / handleRedirectUrl / handleRefreshUrl into smaller and better scoped actions
 export function handleRefreshAccount(history, loader = true) {
@@ -55,12 +58,9 @@ export function handleRefreshAccount(history, loader = true) {
                     // We have an account in the storage, but it doesn't exist on blockchain. We probably nuked storage so just redirect to create account
                     // TODO: Offer to remove specific account vs clearing everything?
                     wallet.clearAccountState()
-                    wallet.redirectToCreateAccount(
-                        {
-                            reset_accounts: true
-                        },
-                        history
-                    )
+                    dispatch(redirectToCreateAccount({
+                        reset_accounts: true
+                    }))
                 }
             })
             .finally(() => {
@@ -183,6 +183,13 @@ export const allowLogin = () => async (dispatch, getState) => {
     } else {
         await dispatch(push({ pathname: '/authorized-apps' }))
     }
+}
+
+const redirectToCreateAccount = (options = {}) => (dispatch) => {
+    dispatch(push({ 
+        pathname: WALLET_CREATE_NEW_ACCOUNT_URL,
+        search: stringify(options)
+    }))
 }
 
 const defaultCodesFor = (prefix, data) => ({ successCode: `${prefix}.success`, errorCode: `${prefix}.error`, data})

--- a/src/components/Routing.js
+++ b/src/components/Routing.js
@@ -32,7 +32,7 @@ import { AddNodeWithRouter } from './node-staking/AddNode'
 import { NodeDetailsWithRouter } from './node-staking/NodeDetails'
 import { StakingWithRouter } from './node-staking/Staking'
 
-import { WALLET_CREATE_NEW_ACCOUNT_URL, WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS } from '../utils/wallet'
+import { WALLET_CREATE_NEW_ACCOUNT_URL } from '../utils/wallet'
 
 import { handleRefreshAccount, handleRefreshUrl, clearAlert, clear, handleRedirectUrl, handleLoginUrl } from '../actions/account'
 
@@ -41,6 +41,7 @@ import { SetupSeedPhraseWithRouter } from './accounts/SetupSeedPhrase'
 const theme = {}
 
 const PATH_PREFIX = process.env.PUBLIC_URL
+const WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS = [`create`, 'set-recovery', 'setup-seed-phrase', 'recover-account', 'recover-seed-phrase']
 
 class Routing extends Component {
     constructor(props) {

--- a/src/components/accounts/AccountFormContainer.js
+++ b/src/components/accounts/AccountFormContainer.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Container, Grid, Header } from 'semantic-ui-react'
 import { parse } from 'query-string'
+import { Translate } from 'react-localize-redux'
 
 import Disclaimer from '../common/Disclaimer'
 
@@ -74,7 +75,7 @@ const AccountFormContainer = ({ location, title, text, children, wide, disclaime
                <Header as='h2'>{text}</Header>
                {location && parse(location.search).reset_accounts && (
                   <Header as='h3' className='color-blue'>
-                     You have been redirected to this page because we had to reset the developer accounts. Please create a new account. We apologize for the inconveience.
+                     <Translate id='account.create.errorAccountNotExist' />
                   </Header>
                )}
             </Grid.Column>

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -7,6 +7,7 @@
     "account.recoverAccount.error": "Failed to recover account.",
     "account.create.success": "Congrats! This name is available.",
     "account.create.error": "Username is taken. Try something else.",
+    "account.create.errorAccountNotExist": "There was a problem creating your account. Please try again!",
     "account.available.success": "User found.",
     "account.available.error": "User not found.",
     "account.available.errorSameAccount": "Cannot send to yourself.",

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -9,7 +9,6 @@ import { store } from '..'
 import { getAccessKeys } from '../actions/account'
 
 export const WALLET_CREATE_NEW_ACCOUNT_URL = `/create`
-export const WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS = [`create`, 'set-recovery', 'setup-seed-phrase', 'recover-account', 'recover-seed-phrase']
 
 const NETWORK_ID = process.env.REACT_APP_NETWORK_ID || 'default'
 const ACCOUNT_HELPER_URL = process.env.REACT_APP_ACCOUNT_HELPER_URL || 'https://near-contract-helper.onrender.com'
@@ -117,26 +116,6 @@ export class Wallet {
 
     async sendMoney(receiverId, amount) {
         await this.getAccount(this.accountId).sendMoney(receiverId, amount)
-    }
-
-    redirectToCreateAccount(options = {}, history) {
-        const param = {
-            next_url: window.location.search
-        }
-        if (options.reset_accounts) {
-            param.reset_accounts = true
-        }
-        //  let url = WALLET_CREATE_NEW_ACCOUNT_URL + "?" + $.param(param)
-        let url =
-            WALLET_CREATE_NEW_ACCOUNT_URL +
-            '/?' +
-            Object.keys(param).map(
-                (p, i) =>
-                    `${i ? '&' : ''}${encodeURIComponent(p)}=${encodeURIComponent(
-                        param[p]
-                    )}`
-            )
-        history ? history.push(url) : window.location.replace(url)
     }
 
     isEmpty() {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -209,11 +209,14 @@ export class Wallet {
         this.checkNewAccount(accountId)
 
         const keyPair = nearlib.KeyPair.fromRandom('ed25519')
-        await sendJson('POST', CONTRACT_CREATE_ACCOUNT_URL, {
-            newAccountId: accountId,
-            newAccountPublicKey: keyPair.publicKey.toString()
-        })
-        await this.saveAndSelectAccount(accountId, keyPair);
+        try {
+            await sendJson('POST', CONTRACT_CREATE_ACCOUNT_URL, {
+                newAccountId: accountId,
+                newAccountPublicKey: keyPair.publicKey.toString()
+            })
+        } finally {
+            await this.saveAndSelectAccount(accountId, keyPair);
+        }
     }
 
     async saveAndSelectAccount(accountId, keyPair) {
@@ -250,6 +253,16 @@ export class Wallet {
         this.accounts = {}
         this.accountId = ''
         this.save()
+    }
+
+    clearAccountState() {
+        delete this.accounts[this.accountId]
+        this.accountId = ''
+        this.save()
+
+        if (!this.isEmpty()) {
+            this.selectAccount(Object.keys(this.accounts)[0])
+        }
     }
 
     getAccount(accountId) {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -214,8 +214,14 @@ export class Wallet {
                 newAccountId: accountId,
                 newAccountPublicKey: keyPair.publicKey.toString()
             })
-        } finally {
             await this.saveAndSelectAccount(accountId, keyPair);
+        } catch(e) {
+            if (e.toString().indexOf('send_tx_commit has timed out') !== -1 || e instanceof TypeError) {
+                await this.saveAndSelectAccount(accountId, keyPair);
+            }
+            else {
+                throw e
+            }
         }
     }
 

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -143,12 +143,6 @@ export class Wallet {
         return !this.accounts || !Object.keys(this.accounts).length
     }
 
-    redirectIfEmpty(history) {
-        if (this.isEmpty()) {
-            this.redirectToCreateAccount({}, history)
-        }
-    }
-
     async loadAccount(accountId) {
         if (!(accountId in this.accounts)) {
             throw new Error('Account ' + accountId + " doesn't exist.")


### PR DESCRIPTION
@vgrichina @kcole16 
With these changes, when an error occurs (on blockchain) while creating an account it will be still saved in Local Storage. There are two cases now:
1. If the account was created in blockchain but some error occurred, then the user will be able to continue with set recovery, like nothing happens.
2. If the account was not created in blockchain, it will be still saved in Local Storage, but immediately after this action (or anytime when user enters wallet) check is performed and the account will be removed from Local Storage.

With case 2. there might be a situation where user have other accounts, so I added additional functionality that will log him into another (first of list) account, so he will be able to continue with Wallet. Without that, user will not be able to login to different accounts until creating new one (because if user is not logged in, the list of accounts is not available).

I think we should also refine text message for case 2. for something like "The account is saved in Local Storage, but it doesn't exist on blockchain. The account was removed from Local Storage and you ware logged in to another account. You can try creating account with the same name again.". @kcole16 ?