### PR TITLE
Fix button feedback delayed on Protect your Account and Setup Recovery Phrase pages

### DIFF
--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -26,7 +26,7 @@ const loaderReducer = (state, { type, ready }) => {
       return state
    }
 
-   const actionsPending = !ready ? [...state.actionsPending, type] : [...state.actionsPending.slice(0, -1)]
+   const actionsPending = !ready ? [...state.actionsPending, type] : state.actionsPending.slice(0, -1)
    return { 
       ...state, 
       formLoader: !!actionsPending.length,

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -17,25 +17,19 @@ import {
 
 const initialState = {
    formLoader: false,
-   sentMessage: false
+   sentMessage: false,
+   actionsPending: []
 }
-
-const actionsPending = []
 
 const loaderReducer = (state, { type, ready }) => {
    if (typeof ready === 'undefined') {
       return state
    }
 
-   if (!ready) {
-      actionsPending.push(type)
-   } else {
-      actionsPending.pop()
-   }
    return { 
       ...state, 
-      formLoader: !!actionsPending.length,
-      actionsPending
+      formLoader: !!state.actionsPending.length,
+      actionsPending: !ready ? [...state.actionsPending, type] : [...state.actionsPending.slice(0, -1)]
    }
 }
 

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -20,7 +20,7 @@ const initialState = {
    sentMessage: false
 }
 
-const loaderReducerPendingStack = []
+const actionsPending = []
 
 const loaderReducer = (state, { type, ready }) => {
    if (typeof ready === 'undefined') {
@@ -28,11 +28,15 @@ const loaderReducer = (state, { type, ready }) => {
    }
 
    if (!ready) {
-      loaderReducerPendingStack.push(type)
+      actionsPending.push(type)
    } else {
-      loaderReducerPendingStack.pop()
+      actionsPending.pop()
    }
-   return { ...state, formLoader: !!loaderReducerPendingStack.length }
+   return { 
+      ...state, 
+      formLoader: !!actionsPending.length,
+      actionsPending
+   }
 }
 
 const globalAlertReducer = handleActions({

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -26,10 +26,11 @@ const loaderReducer = (state, { type, ready }) => {
       return state
    }
 
+   const actionsPending = !ready ? [...state.actionsPending, type] : [...state.actionsPending.slice(0, -1)]
    return { 
       ...state, 
-      formLoader: !!state.actionsPending.length,
-      actionsPending: !ready ? [...state.actionsPending, type] : [...state.actionsPending.slice(0, -1)]
+      formLoader: !!actionsPending.length,
+      actionsPending
    }
 }
 

--- a/src/reducers/account/index.js
+++ b/src/reducers/account/index.js
@@ -20,11 +20,19 @@ const initialState = {
    sentMessage: false
 }
 
-const loaderReducer = (state, { ready }) => {
+const loaderReducerPendingStack = []
+
+const loaderReducer = (state, { type, ready }) => {
    if (typeof ready === 'undefined') {
       return state
    }
-   return { ...state, formLoader: !ready }
+
+   if (!ready) {
+      loaderReducerPendingStack.push(type)
+   } else {
+      loaderReducerPendingStack.pop()
+   }
+   return { ...state, formLoader: !!loaderReducerPendingStack.length }
 }
 
 const globalAlertReducer = handleActions({


### PR DESCRIPTION
@vgrichina The thing is that `setupRecoveryMessage` action contains another action, in this case `getAccessKeys`, so after `getAccessKeys` action is completed (and before `setupRecoveryMessage` is completed) the `loaderReducer` did set `formLoader` state to `false`, so the button was available. 
I added a stack to `loaderReducer` that will store all actions that started, so we will wait with setting `formLoader` to `false` till all actions are completed.

@kcole16  The same problem was on Setup Recovery Phrase page, so it's fixed with this change as well.