### PR TITLE
Display yoctoN in title tag if amount is <=0.0001 (#290)

### DIFF
--- a/src/components/common/Balance.js
+++ b/src/components/common/Balance.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
-import { List } from 'semantic-ui-react';
-import { utils } from 'nearlib';
+import { List } from 'semantic-ui-react'
+import { utils } from 'nearlib'
+import { BN } from 'bn.js'
 
 const CustomDiv = styled(List)`
     position: relative;
@@ -9,26 +10,38 @@ const CustomDiv = styled(List)`
 `
 
 const FRAC_DIGITS = 5
+const YOCTO_NEAR_THRESHOLD = new BN('10', 10).pow(new BN(utils.format.NEAR_NOMINATION_EXP - FRAC_DIGITS + 1, 10))
 
 const Balance = ({ amount }) => {
     if (!amount) {
-        throw new Error("amount property should not be null")
+        throw new Error('amount property should not be null')
     }
     let amountShow = formatNEAR(amount)
 
     return (
-        <CustomDiv title={['0','0.0001'].includes(utils.format.formatNearAmount(amount, (FRAC_DIGITS || 1) - 1)) ? `${formatWithCommas(amount)} yoctoⓃ` : ``}>
+        <CustomDiv title={showInYocto(amount)}>
             {amountShow} Ⓝ
         </CustomDiv>
     )
 }
 
 export const formatNEAR = (amount) => {
-    let ret =  utils.format.formatNearAmount(amount, FRAC_DIGITS);
+    let ret =  utils.format.formatNearAmount(amount, FRAC_DIGITS)
     if (ret === '0') {
-        return `<${!FRAC_DIGITS ? `0` : `0.${'0'.repeat((FRAC_DIGITS || 1) - 1)}1`}`
+        return `<${
+            !FRAC_DIGITS 
+                ? `0` 
+                : `0.${'0'.repeat((FRAC_DIGITS || 1) - 1)}1`
+        }`
     }
-    return ret;
+    return ret
+}
+
+const showInYocto = (amountStr) => {
+    const amount = new BN(amountStr)
+    if (amount.lte(YOCTO_NEAR_THRESHOLD)) {
+        return formatWithCommas(amountStr) + ' yoctoⓃ'
+    }
 }
 
 const formatWithCommas = (value) => {

--- a/src/components/common/Balance.js
+++ b/src/components/common/Balance.js
@@ -8,24 +8,35 @@ const CustomDiv = styled(List)`
     display: inline;
 `
 
+const FRAC_DIGITS = 5
+
 const Balance = ({ amount }) => {
     if (!amount) {
         throw new Error("amount property should not be null")
     }
     let amountShow = formatNEAR(amount)
+
     return (
-        <CustomDiv>
+        <CustomDiv title={['0','0.0001'].includes(utils.format.formatNearAmount(amount, (FRAC_DIGITS || 1) - 1)) ? `${formatWithCommas(amount)} yoctoⓃ` : ``}>
             {amountShow} Ⓝ
         </CustomDiv>
     )
 }
 
 export const formatNEAR = (amount) => {
-    let ret =  utils.format.formatNearAmount(amount, 5);
+    let ret =  utils.format.formatNearAmount(amount, FRAC_DIGITS);
     if (ret === '0') {
-        return "<0.00001";
+        return `<${!FRAC_DIGITS ? `0` : `0.${'0'.repeat((FRAC_DIGITS || 1) - 1)}1`}`
     }
     return ret;
+}
+
+const formatWithCommas = (value) => {
+    const pattern = /(-?\d+)(\d{3})/
+    while (pattern.test(value)) {
+        value = value.replace(pattern, '$1,$2')
+    }
+    return value
 }
 
 export default Balance


### PR DESCRIPTION
I added `FRAC_DIGITS` so it will be easy to change number of fractional digits in the future.

`formatWithCommas` is copied from nearlib utils, it can be removed if we can export this function from nearlib.