### PR TITLE
Add support for showing generic profiles

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -8,6 +8,11 @@ export const REFRESH_ACCOUNT = 'REFRESH_ACCOUNT'
 export const LOADER_ACCOUNT = 'LOADER_ACCOUNT'
 export const REFRESH_URL = 'REFRESH_URL'
 
+export const loadAccount = createAction('LOAD_ACCOUNT',
+    accountId => wallet.getAccount(accountId).state(),
+    accountId => ({ accountId })
+)
+
 // TODO: Refactor whole mess with handleRefreshAccount / handleLoginUrl / handleRedirectUrl / handleRefreshUrl into smaller and better scoped actions
 export function handleRefreshAccount(history, loader = true) {
     return (dispatch, getState) => {

--- a/src/components/Routing.js
+++ b/src/components/Routing.js
@@ -26,7 +26,7 @@ import { AuthorizedAppsWithRouter } from './access-keys/AccessKeys'
 import { FullAccessKeysWithRouter } from './access-keys/AccessKeys'
 import { SendMoneyWithRouter } from './send-money/SendMoney'
 import { ReceiveMoneyWithRouter } from './receive-money/ReceiveMoney'
-import { ProfileWithRouter } from './profile/Profile'
+import { Profile } from './profile/Profile'
 import { SignWithRouter } from './sign/Sign'
 import { NodeStakingWithRouter } from './node-staking/NodeStaking'
 import { AddNodeWithRouter } from './node-staking/AddNode'
@@ -58,10 +58,10 @@ class Routing extends Component {
         })
         this.props.addTranslationForLanguage(translations_en, "en")
     }
-    
+
     componentDidMount = () => {
         const { handleRefreshAccount, handleRefreshUrl, history, clearAlert, clear, handleRedirectUrl, handleLoginUrl, router } = this.props
-        
+
         handleRefreshUrl()
         handleRefreshAccount(history)
 
@@ -79,12 +79,12 @@ class Routing extends Component {
             }
 
             handleRefreshAccount(history, false)
-            
+
             const { state: { globalAlertPreventClear } = {} } = history.location
             if (!globalAlertPreventClear) {
                 clearAlert()
             }
-            
+
             clear()
         })
     }
@@ -164,8 +164,8 @@ class Routing extends Component {
                                     />
                                     <PrivateRoute
                                         exact
-                                        path='/profile'
-                                        component={ProfileWithRouter}
+                                        path='/profile/:accountId'
+                                        component={Profile}
                                     />
                                     <PrivateRoute
                                         exact
@@ -192,8 +192,8 @@ class Routing extends Component {
                                         path='/staking'
                                         component={StakingWithRouter}
                                     />
-                                    <PrivateRoute 
-                                        component={DashboardDetailWithRouter} 
+                                    <PrivateRoute
+                                        component={DashboardDetailWithRouter}
                                     />
                                 </Switch>
                             )}

--- a/src/components/profile/Profile.js
+++ b/src/components/profile/Profile.js
@@ -1,44 +1,20 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
 
 import PageContainer from '../common/PageContainer';
 import ProfileDetails from './ProfileDetails'
 import ProfileSection from './ProfileSection'
 import ProfileQRCode from './ProfileQRCode';
-import { Wallet } from '../../utils/wallet'
-
-const wallet = new Wallet()
+import { LOADING, NOT_FOUND, useAccount } from '../../hooks/allAccounts'
 
 export function Profile({ match }) {
     const { accountId } = match.params
-    const currentUser = useSelector(state => state.account)
-    const [ account, setAccount ] = React.useState(
-        currentUser.accountId === accountId && currentUser
-    )
-    const [ loading, setLoading ] = React.useState(!account)
+    const account = useAccount(accountId)
 
-    React.useEffect(() => {
-        if (currentUser.accountId === accountId) {
-            setAccount(currentUser)
-        } else {
-            setLoading(true)
-            wallet.getAccount(accountId).state()
-                .then(({ amount }) => {
-                    setLoading(false)
-                    setAccount({ accountId, amount })
-                })
-                .catch(err => {
-                    setLoading(false)
-                    setAccount(null)
-                })
-        }
-    }, [accountId])
-
-    if (loading) {
+    if (account.__status === LOADING) {
         return <PageContainer title="Loading..." />
     }
 
-    if (!account) {
+    if (account.__status === NOT_FOUND) {
         return <PageContainer title={`Account @${accountId} not found`} />
     }
 

--- a/src/components/profile/Profile.js
+++ b/src/components/profile/Profile.js
@@ -1,51 +1,53 @@
-import React, { Component } from 'react'
-import { connect } from 'react-redux'
-
-import { withRouter } from 'react-router-dom'
+import React from 'react'
+import { useSelector } from 'react-redux'
 
 import PageContainer from '../common/PageContainer';
 import ProfileDetails from './ProfileDetails'
 import ProfileSection from './ProfileSection'
-import ProfileYourKeys from './ProfileYourKeys'
-import ProfileNotice from './ProfileNotice'
 import ProfileQRCode from './ProfileQRCode';
+import { Wallet } from '../../utils/wallet'
 
-class Profile extends Component {
-   state = {
-      loader: false
-   }
+const wallet = new Wallet()
 
-   componentDidMount() {}
+export function Profile({ match }) {
+    const { accountId } = match.params
+    const currentUser = useSelector(state => state.account)
+    const [ account, setAccount ] = React.useState(
+        currentUser.accountId === accountId && currentUser
+    )
+    const [ loading, setLoading ] = React.useState(!account)
 
-   render() {
-      const { account } = this.props
+    React.useEffect(() => {
+        if (currentUser.accountId === accountId) {
+            setAccount(currentUser)
+        } else {
+            setLoading(true)
+            wallet.getAccount(accountId).state()
+                .then(({ amount }) => {
+                    setLoading(false)
+                    setAccount({ accountId, amount })
+                })
+                .catch(err => {
+                    setLoading(false)
+                    setAccount(null)
+                })
+        }
+    }, [accountId])
 
-      return (
-         <PageContainer
-            title={`Account: @${account.accountId ? account.accountId : ``}`}
-         >
+    if (loading) {
+        return <PageContainer title="Loading..." />
+    }
+
+    if (!account) {
+        return <PageContainer title={`Account @${accountId} not found`} />
+    }
+
+    return (
+        <PageContainer title={`Account: @${accountId}`}>
             <ProfileSection>
-               <ProfileDetails account={this.props.account} />
-               { false ?
-               <ProfileYourKeys />
-               : null }
-               { false ?
-               <ProfileNotice />
-               : null }
-               <ProfileQRCode account={this.props.account} />
+                <ProfileDetails account={account} />
+                <ProfileQRCode account={account} />
             </ProfileSection>
-         </PageContainer>
-      )
-   }
+        </PageContainer>
+    )
 }
-
-const mapDispatchToProps = {}
-
-const mapStateToProps = ({ account }) => ({
-   account
-})
-
-export const ProfileWithRouter = connect(
-   mapStateToProps,
-   mapDispatchToProps
-)(withRouter(Profile))

--- a/src/components/responsive/DesktopPopup.js
+++ b/src/components/responsive/DesktopPopup.js
@@ -41,7 +41,7 @@ const CustomPopup = styled(Popup)`
                     line-height: 26px;
                     padding-left: 10px;
                 }
-            
+
                 .item {
                     margin: 4px 0;
                     display: flex;
@@ -146,7 +146,7 @@ const DesktopPopup = ({
                 <List className='submenu'>
                     <List.Item>
                         <List.Icon as={Image} src={AccountImage} />
-                        <List.Content as={Link} to='/profile' onClick={handleClose}>
+                        <List.Content as={Link} to={`/profile/${account.accountId}`} onClick={handleClose}>
                             Profile
                         </List.Content>
                     </List.Item>

--- a/src/components/responsive/MobileView.js
+++ b/src/components/responsive/MobileView.js
@@ -30,13 +30,13 @@ const CustomResponsive = styled(Responsive)`
       .navbar {
          padding: 0px;
          padding-bottom: 1rem;
-         
+
          &-main {
             background-color: #24272a;
             height: 72px;
             border-radius: 0;
             margin-bottom: 0;
-            
+
             .mainlogo {
                float: left;
                padding: 4px 10px 0px 0px;
@@ -81,7 +81,7 @@ const CustomResponsive = styled(Responsive)`
                border-top: 1px solid #4a4f54;
                color: #fff;
                letter-spacing: 2px;
-               
+
                &.border {
                   border-bottom: 1px solid #4a4f54;
                }
@@ -101,7 +101,7 @@ const CustomResponsive = styled(Responsive)`
                   padding: 8px 9px;
                   color: #8fd6bd;
                   letter-spacing: 2px;
-                  
+
                   img {
                      margin-top: -2px;
                      width: 18px;
@@ -251,7 +251,7 @@ class MobileView extends Component {
                                 </Menu.Item>
                             </Link>
                             <Menu.Menu className='sub'>
-                                <Link to='/profile' onClick={this.handleDropdown}>
+                                <Link to={`/profile/${account.accountId}`} onClick={this.handleDropdown}>
                                     <Menu.Item>
                                         <Image src={AccountGreyImage} />
                                         Profile

--- a/src/hooks/allAccounts.js
+++ b/src/hooks/allAccounts.js
@@ -1,0 +1,21 @@
+import { useEffect } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { LOADING, NOT_FOUND } from '../reducers/allAccounts'
+import { loadAccount } from '../actions/account'
+
+export { LOADING, NOT_FOUND }
+
+const initialAccountState = { __status: LOADING }
+
+export function useAccount(accountId) {
+    const account = useSelector(state =>
+        state.allAccounts[accountId] || initialAccountState
+    )
+    const dispatch = useDispatch()
+
+    useEffect(() => {
+        if (account.__status === LOADING) dispatch(loadAccount(accountId))
+    }, [accountId])
+
+    return account
+}

--- a/src/reducers/allAccounts.js
+++ b/src/reducers/allAccounts.js
@@ -1,0 +1,30 @@
+import { handleAction } from 'redux-actions'
+import { loadAccount } from '../actions/account'
+
+export const LOADED = Symbol('LOADED')
+export const LOADING = Symbol('LOADING')
+export const NOT_FOUND = Symbol('NOT_FOUND')
+
+const initialState = {}
+
+const reducer = (state, event) => {
+    const { error, meta: { accountId }, payload, ready } = event
+
+    if (!ready) return state
+
+    if (error) {
+        if (payload.message.match('does not exist')) {
+            return { ...state, [accountId]: { __status: NOT_FOUND } }
+        }
+
+        console.error('error loading profile!', payload)
+        return state
+    }
+
+    return {
+        ...state,
+        [accountId]: { accountId, ...payload, __status: LOADED },
+    }
+}
+
+export default handleAction(loadAccount, reducer, initialState)

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,14 +2,16 @@ import { combineReducers } from 'redux'
 import { connectRouter } from 'connected-react-router'
 import { localizeReducer } from 'react-localize-redux';
 
+import allAccounts from '../reducers/allAccounts'
 import account from './account'
 import sign from './sign'
 import availableAccounts from './available-accounts'
 
 export default (history) => combineReducers({
-   localize: localizeReducer,
-   account,
-   availableAccounts,
-   sign,
-   router: connectRouter(history)
+    localize: localizeReducer,
+    allAccounts,
+    availableAccounts,
+    account,
+    sign,
+    router: connectRouter(history)
 })


### PR DESCRIPTION
Previously, this app would only show you your own profile at `/profile`

This changes the route to `/your-username`, and allows showing anyone else's profile at this route as well

If viewing your own profile, data is loaded immediately from the redux store, which is cached in localStorage. If viewing someone else's, data is fetched directly in the component, since no other components use this data currently and we do not need to pollute the global state with it.

## Screenshots

![near wallet new profile route](https://user-images.githubusercontent.com/221614/73779010-100ae680-475a-11ea-9d4f-35e93157e3d5.gif)
