### PR TITLE
clean up actions: loadAccount has no 2nd arg

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -22,16 +22,16 @@ export function handleRefreshAccount(history, loader = true) {
                 dispatch({
                     type: LOADER_ACCOUNT,
                     loader: false
-                })    
+                })
             }
 
             return false
         }
-        
+
         const accountId = wallet.getAccountId()
 
         wallet
-            .loadAccount(accountId, history)
+            .loadAccount(accountId)
             .then(v => {
                 dispatch({
                     type: REFRESH_ACCOUNT,
@@ -51,7 +51,7 @@ export function handleRefreshAccount(history, loader = true) {
                 if (e.message && e.message.indexOf('does not exist while viewing') !== -1) {
                     // We have an account in the storage, but it doesn't exist on blockchain. We probably nuked storage so just redirect to create account
                     // TODO: Offer to remove specific account vs clearing everything?
-                    wallet.clearState()                    
+                    wallet.clearState()
                     wallet.redirectToCreateAccount(
                         {
                             reset_accounts: true
@@ -141,7 +141,7 @@ export function handleRefreshUrl() {
             type: REFRESH_URL,
             url: accountUrl
         })
-        
+
         const { transactions } = parse(location.search)
         if (transactions) {
             dispatch(parseTransactionsToSign(transactions))


### PR DESCRIPTION
In 1b0d3a1d70363e7578a053c737c3aebc7326d3, `loadAccount` stopped using the `history` argument. In 57e22bea8abc978df0c7d4b7bd230ce3558ca2d5, it stopped paying attention to the second argument passed in altogether.

actions/account.js is free to stop sending a second argument

Note that my editor is also configured to strip trailing whitespace from lines, which adds some noise to this change