### PR TITLE
Clean ProfileQRCode: simplify styles; fix grammar

### DIFF
--- a/src/components/profile/ProfileQRCode.js
+++ b/src/components/profile/ProfileQRCode.js
@@ -4,16 +4,10 @@ import styled from 'styled-components'
 import { QRCode } from "react-qr-svg";
 
 const CustomDiv = styled.div`
-    & {
-        text-align: center;
-    }
+    text-align: center;
 
-    h2 {
-        margin-bottom: 1em;
-    }
-    
     p {
-        margin-top: 1em;    
+        margin-top: 1em;
     }
 `
 
@@ -26,7 +20,7 @@ const ProfileQRCode = ({ account }) => (
             style={{ width: "100%" }}
             value={`${window.location.protocol}//${window.location.host}/send-money/${account.accountId}`}
         />
-        <p>Use your phones camera app to send to this address.</p>
+        <p>Use your phone's camera app to send to this address</p>
    </CustomDiv>
 )
 


### PR DESCRIPTION
* No need for the `&`, as root declaration will already be for the component-being-styled
* `h2` removed from markup in 17e102d772ac2c628a026f8a6bafd976a75e916f, we no longer need style rules for it
* grammar: "your phone's camera", we need an apostrophe for the possessive