### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+# https://EditorConfig.org
+
+[*]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This project uses a mix of 3 spaces and 4 spaces for indentation, and is in the process of moving toward 4 spaces everywhere (see example at 740d03c)

Adding a `.editorconfig` file makes it easier to keep this consistent throughout the project, as long as contributors configure their editors to pay attention to this file.

Find an editorconfig plugin for your editor at https://editorconfig.org/#download