### PR TITLE
Navbar: only show account info if it exists

### DIFF
--- a/src/components/responsive/DesktopPopup.js
+++ b/src/components/responsive/DesktopPopup.js
@@ -15,8 +15,8 @@ const CustomPopup = styled(Popup)`
     &&& {
         padding: 0px;
         left: -50px !important;
-        top: 15px !important;
         position: fixed !important;
+        top: ${props => props.loggedIn === true ? "15px !important" : "35px !important"};
 
         .account-dropdown {
             width: 290px;
@@ -121,6 +121,7 @@ const DesktopPopup = ({
     popupOpen
 }) => (
         <CustomPopup
+            loggedIn={account.accountId ? true : false}
             trigger={
                 <PopupMenuTrigger
                     account={account}

--- a/src/components/responsive/PopupMenuTrigger.js
+++ b/src/components/responsive/PopupMenuTrigger.js
@@ -90,30 +90,32 @@ const PopupMenuTrigger = ({ account, handleClick, type, dropdown = false, locati
             )}
             {type === 'desktop' && <Image src={ArrowDownImage} />}
          </div>
-         <div className='overflow'>
-            <div className='account-name'>
-               {account.loader || !account.accountId ? (
-                  <Loader active inline size='mini' />
-               ) : (
-                  `@${account.accountId}`
-               )}
-            </div>
-            <div className={`account-tokens ${location.pathname === `/node-staking` ? `node-staking` : ``}`}>
-               {account.loader || !account.accountId ? (
-                  <Loader active inline size='mini' />
-               ) : (
-                     <div>
-                        {account.amount 
-                        ? <Balance amount={account.amount} /> 
-                        : 'NaN'}
-
-                        {location.pathname === '/node-staking' && (
-                           <div className='staking'>&nbsp;/ 202,250.0025</div>
-                        )}
-                     </div>
+         {account.accountId &&
+            <div className='overflow'>
+               <div className='account-name'>
+                  {account.loader ? (
+                     <Loader active inline size='mini' />
+                  ) : (
+                     `@${account.accountId}`
                   )}
+               </div>
+               <div className={`account-tokens ${location.pathname === `/node-staking` ? `node-staking` : ``}`}>
+                  {account.loader ? (
+                     <Loader active inline size='mini' />
+                  ) : (
+                        <div>
+                           {account.amount 
+                           ? <Balance amount={account.amount} /> 
+                           : 'NaN'}
+
+                           {location.pathname === '/node-staking' && (
+                              <div className='staking'>&nbsp;/ 202,250.0025</div>
+                           )}
+                        </div>
+                     )}
+               </div>
             </div>
-         </div>
+         }
       </div>
    </CustomDiv>
 )


### PR DESCRIPTION
Previously we always showed a spinner if there's no account info. Now we only show spinner if it's actually loading

Issue first mentioned [here](https://github.com/nearprotocol/near-wallet/pull/359#issuecomment-582189411)