### PR TITLE
Sign TX: convert tx value to string before formatting

### DIFF
--- a/src/components/common/Balance.js
+++ b/src/components/common/Balance.js
@@ -47,7 +47,7 @@ const showInYocto = (amountStr) => {
 const formatWithCommas = (value) => {
     const pattern = /(-?\d+)(\d{3})/
     while (pattern.test(value)) {
-        value = value.replace(pattern, '$1,$2')
+        value = value.toString().replace(pattern, '$1,$2')
     }
     return value
 }


### PR DESCRIPTION
This fixes TX signing from breaking when value is below threshold. https://github.com/nearprotocol/near-wallet/commit/da2ed7cc92975ddef08231e7e1a685cb3ae6ba37 