### PR TITLE
Login to app: don't show GlobalAlert if there's a success url

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -80,6 +80,7 @@ export const allowLogin = () => async (dispatch, getState) => {
 
     const { success_url, public_key } = url
     if (success_url) {
+        dispatch(clearAlert())
         const availableKeys = await wallet.getAvailableKeys();
         const allKeys = availableKeys.map(key => key.toString());
         const parsedUrl = new URL(success_url)

--- a/src/components/responsive/GlobalAlert.js
+++ b/src/components/responsive/GlobalAlert.js
@@ -44,7 +44,7 @@ const CustomMessage = styled(Message)`
         .content {
             color: #999;
             line-height: 20px;
-            word-break: break-all;
+            word-break: break-word;
 
             .header {
                 font-size: 18px;


### PR DESCRIPTION
Re-directing user back to app at the same time as we show the success alert is confusing since user doesn't have time to read/understand the alert. Removing it if there's a re-direct url.