### PR TITLE
refactor: rm obsolete validateCode and others

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -42,7 +42,7 @@ export const parseTransactionsToSign = createAction('PARSE_TRANSACTIONS_TO_SIGN'
 export function handleRefreshUrl() {
     return (dispatch, getState) => {
         const { pathname, search } = getState().router.location
-        
+
         if (pathname.split('/')[1] === WALLET_LOGIN_URL && search !== '') {
             saveState(parse(search))
             dispatch(refreshUrl(parse(search)))
@@ -94,22 +94,14 @@ export const allowLogin = () => async (dispatch, getState) => {
 
 const defaultCodesFor = (prefix, data) => ({ successCode: `${prefix}.success`, errorCode: `${prefix}.error`, data})
 
-export const { requestCode, setupAccountRecovery, setupRecoveryMessage, recoverAccount, checkNewAccount, createNewAccount, checkAccountAvailable, getTransactions, clear, clearCode } = createActions({
+export const { requestCode, setupRecoveryMessage, checkNewAccount, createNewAccount, checkAccountAvailable, getTransactions, clear, clearCode } = createActions({
     REQUEST_CODE: [
         wallet.requestCode.bind(wallet),
         () => defaultCodesFor('account.requestCode')
     ],
-    SETUP_ACCOUNT_RECOVERY: [
-        wallet.setupAccountRecovery.bind(wallet),
-        () => defaultCodesFor('account.setupAccountRecovery')
-    ],
     SETUP_RECOVERY_MESSAGE: [
         wallet.setupRecoveryMessage.bind(wallet),
         () => defaultCodesFor('account.setupRecoveryMessage')
-    ],
-    RECOVER_ACCOUNT: [
-        wallet.recoverAccount.bind(wallet),
-        () => defaultCodesFor('account.recoverAccount')
     ],
     CHECK_NEW_ACCOUNT: [
         wallet.checkNewAccount.bind(wallet),

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -1,8 +1,6 @@
 {
     "account.requestCode.success": "Sent SMS with code.",
     "account.requestCode.error": "Failed to send SMS with code.",
-    "account.setupAccountRecovery.success": "Success",
-    "account.setupAccountRecovery.error": "Failed to setup account recovery.",
     "account.recoverAccount.success": "Success",
     "account.recoverAccount.error": "Failed to recover account.",
     "account.create.success": "Congrats! This name is available.",
@@ -16,7 +14,7 @@
     "account.login.success": "${title} is now authorized to use your account.",
     "account.login.error": "An error occurred while approving this action. Please try again!",
     "account.login.details.warning": "This allows access to your entire balance. Please proceed with caution.",
-    
+
     "actions": {
         "CreateAccount": "New account created: @${receiverId}",
         "DeleteAccount": "Account deleted: @${receiverId}",
@@ -90,7 +88,7 @@
         "publicKey": "Public Key",
         "ledger": "Ledger"
     },
-    
+
     "button": {
         "copyPhrase": "COPY PHRASE",
         "continue": "CONTINUE",


### PR DESCRIPTION
`validateCode` was only used by `setupAccountRecovery` and `recoverAccount`, which are no longer used