### PR TITLE
Add fallback 'copy to clipboard' method

### DIFF
--- a/src/utils/copyText.js
+++ b/src/utils/copyText.js
@@ -1,8 +1,12 @@
 const copyText = (el) => {
-    const selection = window.getSelection();
-    selection.selectAllChildren(el);
-    document.execCommand('copy');
-    selection.removeAllRanges();
+    if (navigator.clipboard) {
+        navigator.clipboard.writeText(el.textContent);
+    } else {
+        const selection = window.getSelection();
+        selection.selectAllChildren(el);
+        document.execCommand('copy');
+        selection.removeAllRanges();
+    }
 }
 
 export default copyText;


### PR DESCRIPTION
Chrome, Firefox, IE: `clipboard.writeText`
Safari: `document.execCommand('copy');`