### PR TITLE
Update seed phrase recovery copy

### DIFF
--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -209,11 +209,11 @@
         "pageTitle": "Recover using Seed Phrase",
         "pageText": "Enter the backup seed phrase associated with the account.",
         "accountIdInput": {
-            "title": "Choose a Username"
+            "title": "Username"
         },
         "seedPhraseInput": {
-            "title": "Seed Phrase",
-            "placeholder": "correct horse battery staple"
+            "title": "Seed Phrase (12 words)",
+            "placeholder": "correct horse battery staple..."
         }
     },
 


### PR DESCRIPTION
Updated the seed phrase recovery labels (`Choose a Username` -> `Username`, `Seed Phrase` -> `Seed Phrase (12 words)`) and placeholder.

<img width="450" alt="Screen Shot 2020-04-15 at 12 08 09 PM" src="https://user-images.githubusercontent.com/5624527/79396926-c4cb3c00-7f31-11ea-9134-c4554139bdc0.png">


<a href="https://gitpod.io/#https://github.com/nearprotocol/near-wallet/pull/522"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nearprotocol/near-wallet.git/149d801483ef9c9b5426a13725eacfc2f6861a7e.svg" /></a>

