### PR TITLE
Make all info about TLA use env var

### DIFF
--- a/src/components/accounts/AccountFormAccountId.js
+++ b/src/components/accounts/AccountFormAccountId.js
@@ -101,11 +101,11 @@ class AccountFormAccountId extends Component {
                             {type === 'create' &&
                                 <Modal
                                     size='mini'
-                                    trigger={<DomainName>{ACCOUNT_ID_SUFFIX}<InfoIcon/></DomainName>}
+                                    trigger={<DomainName>.{ACCOUNT_ID_SUFFIX}<InfoIcon/></DomainName>}
                                     closeIcon
                                 >
-                                    <Header>Top Level Accounts</Header>
-                                    Account names are similar to domain names. Only the @testnet account can create accounts such as @yourname.testnet, and only @yourname.testnet can create @app.yourname.testnet. All accounts created in this wallet use the .testnet Top Level Account (TLA). To learn more about account names and creating your own TLA, visit the <a rel='noopener noreferrer' href='https://docs.nearprotocol.com/docs/concepts/account'>docs</a>.
+                                    <Header>{translate('topLevelAccounts.header')}</Header>
+                                    {translate('topLevelAccounts.body', { suffix: ACCOUNT_ID_SUFFIX })}
                                 </Modal>
                             }
                         </InputWrapper>

--- a/src/translations/en.global.json
+++ b/src/translations/en.global.json
@@ -205,6 +205,11 @@
         }
     },
 
+    "topLevelAccounts": {
+        "header": "Top Level Accounts",
+        "body": "Account names are similar to domain names. Only the @${suffix} account can create accounts such as @yourname.${suffix}, and only @yourname.${suffix} can create @app.yourname.${suffix}. All accounts created in this wallet use the .${suffix} Top Level Account (TLA). To learn more about account names and creating your own TLA, visit the <a rel='noopener noreferrer' href='https://docs.nearprotocol.com/docs/concepts/account'>docs</a>."
+    },
+
     "recoverSeedPhrase": {
         "pageTitle": "Recover using Seed Phrase",
         "pageText": "Enter the backup seed phrase associated with the account.",

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -13,7 +13,7 @@ export const WALLET_LOGIN_URL = 'login'
 export const ACCOUNT_HELPER_URL = process.env.REACT_APP_ACCOUNT_HELPER_URL || 'https://near-contract-helper.onrender.com'
 
 export const IS_MAINNET = process.env.REACT_APP_IS_MAINNET === 'true' || process.env.REACT_APP_IS_MAINNET === 'yes'
-export const ACCOUNT_ID_SUFFIX = process.env.REACT_APP_ACCOUNT_ID_SUFFIX || '.test'
+export const ACCOUNT_ID_SUFFIX = process.env.REACT_APP_ACCOUNT_ID_SUFFIX || 'test'
 
 const NETWORK_ID = process.env.REACT_APP_NETWORK_ID || 'default'
 const CONTRACT_CREATE_ACCOUNT_URL = `${ACCOUNT_HELPER_URL}/account`


### PR DESCRIPTION
The modal that popped up did not match the suffix shown in the account creation form. This makes them match, and moves the strings of text to the translations file so we don't miss them when translating the interface to new languages.

<a href="https://gitpod.io/#https://github.com/nearprotocol/near-wallet/pull/535"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nearprotocol/near-wallet.git/dcf633c7aa88f03c176d83c8a08b47980f64e8e2.svg" /></a>

